### PR TITLE
Parse metadata from pandoc title block

### DIFF
--- a/pandoc.pm
+++ b/pandoc.pm
@@ -258,13 +258,13 @@ sub htmlize ($@) {
     my $date = compile_string @doc_date;
 
     if ($title) {
-        $pagestate{$page}{meta}{title} = quotemeta($title);
+        $pagestate{$page}{meta}{title} = $title;
     }
     if ($author) {
-        $pagestate{$page}{meta}{author} = quotemeta($author);
+        $pagestate{$page}{meta}{author} = $author;
     }
     if ($date) {
-        $pagestate{$page}{meta}{date} = quotemeta($date);
+        $pagestate{$page}{meta}{date} = $date;
     }
 
     return $content;

--- a/pandoc.pm
+++ b/pandoc.pm
@@ -233,7 +233,7 @@ sub htmlize ($@) {
     my $num_authors = @doc_authors;
     my @primary_author = ();
     if ($num_authors gt 0) {
-        my @primary_author = @{$doc_authors[0]};
+        @primary_author = @{$doc_authors[0]};
     }
     my @doc_date = @{$header_section{'docDate'}};
 
@@ -258,13 +258,13 @@ sub htmlize ($@) {
     my $date = compile_string @doc_date;
 
     if ($title) {
-        $pagestate{$page}{meta}{title} = $title;
+        $pagestate{$page}{meta}{title} = quotemeta($title);
     }
     if ($author) {
-        $pagestate{$page}{meta}{author} = $author;
+        $pagestate{$page}{meta}{author} = quotemeta($author);
     }
     if ($date) {
-        $pagestate{$page}{meta}{date} = $date;
+        $pagestate{$page}{meta}{date} = quotemeta($date);
     }
 
     return $content;

--- a/pandoc.pm
+++ b/pandoc.pm
@@ -244,7 +244,9 @@ sub htmlize ($@) {
         my $compiled_string = '';
         foreach my $word_or_space(@uncompiled_string) {
             if (ref($word_or_space) eq "HASH") {
-                $compiled_string .= $word_or_space->{"Str"};
+                if ($word_or_space->{"Str"}) {
+                    $compiled_string .= $word_or_space->{"Str"};
+                }
             }
             else {
                 $compiled_string .= ' ';

--- a/pandoc.pm
+++ b/pandoc.pm
@@ -244,9 +244,19 @@ sub htmlize ($@) {
         return join " ", @string_without_spaces;
     }
 
-    $pagestate{$page}{meta}{title} = compile_string @doc_title;
-    $pagestate{$page}{meta}{author} = compile_string @primary_author;
-    $pagestate{$page}{meta}{date} = compile_string @doc_date;
+    my $title = compile_string @doc_title;
+    my $author = compile_string @primary_author;
+    my $date = compile_string @doc_date;
+
+    if ($title) {
+        $pagestate{$page}{meta}{title} = $title;
+    }
+    if ($author) {
+        $pagestate{$page}{meta}{author} = $author;
+    }
+    if ($date) {
+        $pagestate{$page}{meta}{date} = $date;
+    }
 
     return $content;
 }

--- a/pandoc.pm
+++ b/pandoc.pm
@@ -234,14 +234,19 @@ sub htmlize ($@) {
     my @doc_date = @{$header_section{'docDate'}};
 
     sub compile_string {
+        # The uncompiled string is an array of hashes containing words and 
+        # string with the word "Space".
         my (@uncompiled_string) = @_;
-        my @string_without_spaces;
+        my $compiled_string = '';
         foreach my $word_or_space(@uncompiled_string) {
             if (ref($word_or_space) eq "HASH") {
-                push @string_without_spaces, $word_or_space->{"Str"};
+                $compiled_string .= $word_or_space->{"Str"};
+            }
+            else {
+                $compiled_string .= ' ';
             }
         }
-        return join " ", @string_without_spaces;
+        return $compiled_string;
     }
 
     my $title = compile_string @doc_title;


### PR DESCRIPTION
Instead of converting directly from the source format to HTML, I changed the module to convert to an intermediate JSON form. This JSON represents Pandoc's Markdown's [abstract syntax tree](http://johnmacfarlane.net/pandoc/scripting.html#json-reader-and-writer). From the JSON I am able to parse out the [title block](http://johnmacfarlane.net/pandoc/demo/example19/Title-block.html). Then I pass the title block information on to the meta variable for the page.
